### PR TITLE
feat: add keyboard-driven sidebar window cycling

### DIFF
--- a/src/commands/focus.rs
+++ b/src/commands/focus.rs
@@ -1,0 +1,61 @@
+use crate::niri;
+use crate::Ctx;
+use anyhow::{bail, Result};
+use niri_ipc::{Action, Request};
+
+#[derive(Clone, Copy)]
+pub enum Direction {
+    Next,
+    Prev,
+}
+
+pub fn focus_cycle(ctx: &mut Ctx, direction: Direction) -> Result<()> {
+    let current_ws = niri::get_active_workspace_id(&mut ctx.socket)?;
+    let all_windows = niri::get_windows(&mut ctx.socket)?;
+
+    let sidebar_ids: Vec<u64> = ctx.state.windows.iter().map(|(id, _, _)| *id).collect();
+    let mut sidebar_windows: Vec<_> = all_windows
+        .iter()
+        .filter(|w| {
+            w.is_floating && w.workspace_id == Some(current_ws) && sidebar_ids.contains(&w.id)
+        })
+        .collect();
+
+    if sidebar_windows.is_empty() {
+        bail!("No sidebar windows on the current workspace");
+    }
+
+    // Sort by state order for stable ordering
+    sidebar_windows.sort_by_key(|w| {
+        sidebar_ids
+            .iter()
+            .position(|id| *id == w.id)
+            .unwrap_or(usize::MAX)
+    });
+    if ctx.state.is_flipped {
+        sidebar_windows.reverse();
+    }
+
+    let focused_idx = sidebar_windows.iter().position(|w| w.is_focused);
+
+    let target_idx = match focused_idx {
+        Some(idx) => {
+            let len = sidebar_windows.len();
+            match direction {
+                Direction::Next => (idx + 1) % len,
+                Direction::Prev => (idx + len - 1) % len,
+            }
+        }
+        // No sidebar window focused: enter from the matching end
+        None => match direction {
+            Direction::Next => 0,
+            Direction::Prev => sidebar_windows.len() - 1,
+        },
+    };
+
+    let target_id = sidebar_windows[target_idx].id;
+    let action = Action::FocusWindow { id: target_id };
+    let _ = ctx.socket.send(Request::Action(action))?;
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 mod close;
 mod flip;
+mod focus;
 mod hide;
 mod listen;
 mod reorder;
@@ -7,6 +8,7 @@ mod togglewindow;
 
 pub use close::close;
 pub use flip::toggle_flip;
+pub use focus::{focus_cycle, Direction};
 pub use hide::toggle_visibility;
 pub use listen::listen;
 pub use reorder::reorder;

--- a/src/commands/togglewindow.rs
+++ b/src/commands/togglewindow.rs
@@ -81,5 +81,8 @@ fn remove_from_sidebar(ctx: &mut Ctx, window: &Window) -> Result<()> {
         let _ = ctx.socket.send(Request::Action(toggle_float))?;
     }
 
+    // Return focus to the tiling layout so keyboard navigation works immediately
+    let _ = ctx.socket.send(Request::Action(Action::FocusTiling {}))?;
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,10 @@ enum Commands {
     Reorder,
     /// Close the focused window and reorder the sidebar
     Close,
+    /// Focus the next sidebar window
+    FocusNext,
+    /// Focus the previous sidebar window
+    FocusPrev,
     /// Generate a default config file if none exists
     Init,
     /// Run a daemon to listen for window close events
@@ -80,6 +84,8 @@ fn main() -> Result<()> {
         Commands::Flip => commands::toggle_flip(&mut ctx)?,
         Commands::Reorder => commands::reorder(&mut ctx)?,
         Commands::Close => commands::close(&mut ctx)?,
+        Commands::FocusNext => commands::focus_cycle(&mut ctx, commands::Direction::Next)?,
+        Commands::FocusPrev => commands::focus_cycle(&mut ctx, commands::Direction::Prev)?,
         Commands::Init => unreachable!(),
         Commands::Listen => commands::listen(ctx)?,
     }


### PR DESCRIPTION
## Summary

- Add `focus-next` and `focus-prev` subcommands to cycle focus through sidebar windows via keyboard
- Entering from tiling via `focus-next` starts at the bottom of the stack, `focus-prev` starts at the top, with wrap-around cycling
- After pulling a window out of the sidebar with `toggle-window`, focus automatically returns to the tiling layout
- Update README with keybinding examples, a `niri-focus-column` helper script for seamless tiling/sidebar navigation, and a full workflow guide

## Motivation

Currently, interacting with a sidebar window requires clicking it with the mouse to give it focus. This makes the sidebar awkward in a keyboard-driven workflow. These commands enable a fully keyboard-driven flow:

`Mod+J`/`Mod+K` (enter & cycle sidebar) → `Mod+S` (pull window out) or `Mod+H` (return to tiling)

## Changes

| File | Change |
|------|--------|
| `src/commands/focus.rs` | New — `focus_cycle(ctx, direction)` with `Direction` enum |
| `src/commands/mod.rs` | Register the new module and re-export |
| `src/main.rs` | Add `FocusNext`/`FocusPrev` CLI subcommands |
| `src/commands/togglewindow.rs` | Send `FocusTiling` after removing a window from the sidebar |
| `README.md` | Keybindings, helper script, workflow documentation |

## Test plan

- [ ] Add 2–3 windows to sidebar with `toggle-window`
- [ ] From tiling, run `focus-next` — should focus bottom sidebar window
- [ ] From tiling, run `focus-prev` — should focus top sidebar window
- [ ] Cycle through with repeated presses, verify wrap-around
- [ ] Run `toggle-window` on a focused sidebar window — should pull it out and return focus to tiling
- [ ] Test with empty sidebar — should get clean error message
- [ ] Test with `flip` active — cycling order should reverse

🤖 Generated with [Claude Code](https://claude.com/claude-code)