### PR TITLE
refactor: make get_active_window send FocusedWindow request

### DIFF
--- a/src/commands/togglewindow.rs
+++ b/src/commands/togglewindow.rs
@@ -6,19 +6,14 @@ use anyhow::{Context, Result};
 use niri_ipc::{Action, SizeChange, Window};
 
 pub fn toggle_window<C: NiriClient>(ctx: &mut Ctx<C>) -> Result<()> {
-    let windows = ctx.socket.get_windows()?;
-
-    let focused = windows
-        .iter()
-        .find(|w| w.is_focused)
-        .context("No window focused")?;
+    let focused = ctx.socket.get_active_window()?;
 
     let is_tracked = ctx.state.windows.iter().any(|(id, _, _)| *id == focused.id);
 
     if is_tracked {
-        remove_from_sidebar(ctx, focused)?;
+        remove_from_sidebar(ctx, &focused)?;
     } else {
-        add_to_sidebar(ctx, focused)?;
+        add_to_sidebar(ctx, &focused)?;
     }
 
     save_state(&ctx.state, &ctx.cache_dir)?;

--- a/src/niri.rs
+++ b/src/niri.rs
@@ -24,11 +24,11 @@ impl NiriClient for Socket {
     }
 
     fn get_active_window(&mut self) -> Result<Window> {
-        let windows = self.get_windows()?;
-        windows
-            .into_iter()
-            .find(|w| w.is_focused)
-            .context("No focused window.")
+        match self.send(Request::FocusedWindow)? {
+            Ok(Response::FocusedWindow(Some(window))) => Ok(window),
+            Ok(Response::FocusedWindow(None)) => bail!("No window focused"),
+            _ => bail!("Unexpected response from Niri when fetching windows"),
+        }
     }
 
     fn get_active_workspace(&mut self) -> Result<Workspace> {


### PR DESCRIPTION
This PR makes get_active_window send request to Niri for active window instead of iterating over all windows, it also removes duplicated iteration step in toggle_window