### PR TITLE
feat: add nix flake with package + dev shell + home-manager module, and also add shell completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +324,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "dirs",
  "fslock",
  "niri-ipc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.4", features = ["derive"] }
+clap_complete = "4"
 dirs = "5.0"
 fslock = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/default_config.toml
+++ b/default_config.toml
@@ -25,16 +25,16 @@ bottom = 10
 position = "right"
 # Width of windows when sidebar is hidden in pixels
 peek = 10
-# Width of window when sidebar is hidden but window is focused in pixels
-# set this equal to peek to disable this feature
-# set this equal to sidebar_width + offset_right to make focused windows "unhide"
-# Optional and defaults to peek if ommitted
+# Pixels visible when sidebar is hidden but window is focused
+# Set this equal to peek to disable this feature
+# Set this equal to width + right margin to make focused windows fully "unhide"
+# Optional and defaults to peek if omitted
 focus_peek = 50
 # Whether the sidebar should follow if you switch workspaces
 sticky = false
-# Whether to focus the floating layer when unhiding the sidebar
-# This will focus whichever floating window niri last had focused
-focus_on_unhide = false
+# Automatically focus the appropriate layer when toggling visibility
+# On unhide: focuses the floating layer. On hide: focuses the tiling layer.
+auto_focus_layer = false
 
 # Example window rule
 # all fields are optional if not given a default from other configs will be used

--- a/default_config.toml
+++ b/default_config.toml
@@ -32,6 +32,9 @@ peek = 10
 focus_peek = 50
 # Whether the sidebar should follow if you switch workspaces
 sticky = false
+# Whether to focus the floating layer when unhiding the sidebar
+# This will focus whichever floating window niri last had focused
+focus_on_unhide = false
 
 # Example window rule
 # all fields are optional if not given a default from other configs will be used

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "A sidebar for the Niri window manager";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+    in
+    flake-utils.lib.eachSystem supportedSystems (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages = {
+          niri-sidebar = pkgs.callPackage ./nix/package.nix { };
+          default = self.packages.${system}.niri-sidebar;
+        };
+      }
+    )
+    // {
+      overlays.default = _final: prev: {
+        niri-sidebar = prev.callPackage ./nix/package.nix { };
+      };
+
+      homeManagerModules.default = import ./nix/hm-module.nix self;
+      homeManagerModules.niri-sidebar = self.homeManagerModules.default;
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
         niri-sidebar = prev.callPackage ./nix/package.nix { };
       };
 
-      homeManagerModules.default = import ./nix/hm-module.nix self;
-      homeManagerModules.niri-sidebar = self.homeManagerModules.default;
+      homeModules.default = import ./nix/hm-module.nix self;
+      homeModules.niri-sidebar = self.homeModules.default;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,16 @@
           niri-sidebar = pkgs.callPackage ./nix/package.nix { };
           default = self.packages.${system}.niri-sidebar;
         };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${system}.niri-sidebar ];
+          packages = with pkgs; [
+            cargo
+            rustc
+            clippy
+            rustfmt
+          ];
+        };
       }
     )
     // {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,87 @@
+flake:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.niri-sidebar;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.programs.niri-sidebar = {
+    enable = lib.mkEnableOption "niri-sidebar, a sidebar for the Niri window manager";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = flake.packages.${pkgs.stdenv.hostPlatform.system}.niri-sidebar;
+      defaultText = lib.literalExpression "flake.packages.\${pkgs.stdenv.hostPlatform.system}.niri-sidebar";
+      description = "The niri-sidebar package to use.";
+    };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = { };
+      description = ''
+        Configuration for niri-sidebar, serialized to config.toml.
+        See https://github.com/Vigintillionn/niri-sidebar for options.
+      '';
+      example = lib.literalExpression ''
+        {
+          geometry = {
+            width = 400;
+            height = 335;
+            gap = 10;
+          };
+          margins = {
+            top = 50;
+            right = 10;
+            left = 10;
+            bottom = 10;
+          };
+          interaction = {
+            position = "right";
+            peek = 10;
+            sticky = false;
+          };
+          window_rule = [
+            {
+              app_id = "firefox";
+              title = "^Picture-in-Picture$";
+              width = 700;
+              height = 400;
+              auto_add = true;
+            }
+          ];
+        }
+      '';
+    };
+
+    systemd.enable = lib.mkEnableOption "the niri-sidebar listen daemon as a systemd user service";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."niri-sidebar/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "niri-sidebar-config" cfg.settings;
+    };
+
+    systemd.user.services.niri-sidebar-listen = lib.mkIf cfg.systemd.enable {
+      Unit = {
+        Description = "niri-sidebar listen daemon";
+        PartOf = [ "graphical-session.target" ];
+        After = [ "graphical-session.target" ];
+      };
+      Service = {
+        ExecStart = "${lib.getExe cfg.package} listen";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   rustPlatform,
+  installShellFiles,
   pkg-config,
   wayland,
   libxkbcommon,
@@ -24,11 +25,21 @@ rustPlatform.buildRustPackage {
 
   cargoLock.lockFile = ../Cargo.lock;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
   buildInputs = [
     wayland
     libxkbcommon
   ];
+
+  postInstall = ''
+    installShellCompletion --cmd niri-sidebar \
+      --bash <($out/bin/niri-sidebar completions bash) \
+      --zsh <($out/bin/niri-sidebar completions zsh) \
+      --fish <($out/bin/niri-sidebar completions fish)
+  '';
 
   meta = {
     description = "A sidebar for the Niri window manager";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  wayland,
+  libxkbcommon,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "niri-sidebar";
+  version = "0.1.0";
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.intersection (lib.fileset.fromSource (lib.sources.cleanSource ./..)) (
+      lib.fileset.unions [
+        ../Cargo.toml
+        ../Cargo.lock
+        ../src
+        ../default_config.toml
+      ]
+    );
+  };
+
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    wayland
+    libxkbcommon
+  ];
+
+  meta = {
+    description = "A sidebar for the Niri window manager";
+    homepage = "https://github.com/Vigintillionn/niri-sidebar";
+    license = lib.licenses.mit;
+    mainProgram = "niri-sidebar";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/src/commands/cycle.rs
+++ b/src/commands/cycle.rs
@@ -1,0 +1,115 @@
+use crate::Ctx;
+use crate::commands::reorder;
+use crate::niri::NiriClient;
+use crate::state::save_state;
+use crate::Direction;
+use anyhow::Result;
+
+pub fn cycle<C: NiriClient>(ctx: &mut Ctx<C>, direction: Direction) -> Result<()> {
+    if ctx.state.windows.len() < 2 {
+        return Ok(());
+    }
+
+    match direction {
+        Direction::Next => {
+            let first = ctx.state.windows.remove(0);
+            ctx.state.windows.push(first);
+        }
+        Direction::Prev => {
+            let last = ctx.state.windows.pop().unwrap();
+            ctx.state.windows.insert(0, last);
+        }
+    }
+
+    save_state(&ctx.state, &ctx.cache_dir)?;
+    reorder(ctx)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{AppState, WindowState};
+    use crate::test_utils::{MockNiri, mock_config, mock_window};
+    use tempfile::tempdir;
+
+    fn make_ctx(temp_dir: &tempfile::TempDir) -> Ctx<MockNiri> {
+        let mut state = AppState::default();
+        for id in [1, 2, 3] {
+            state.windows.push(WindowState {
+                id,
+                width: 300,
+                height: 200,
+                is_floating: true,
+                position: Some((1.0, 2.0)),
+            });
+        }
+
+        let mock = MockNiri::new(vec![
+            mock_window(1, false, true, 1, Some((1.0, 2.0))),
+            mock_window(2, false, true, 1, Some((1.0, 2.0))),
+            mock_window(3, false, true, 1, Some((1.0, 2.0))),
+        ]);
+
+        Ctx {
+            state,
+            config: mock_config(),
+            socket: mock,
+            cache_dir: temp_dir.path().to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn test_cycle_next() {
+        let temp_dir = tempdir().unwrap();
+        let mut ctx = make_ctx(&temp_dir);
+
+        // [1, 2, 3] -> [2, 3, 1]
+        cycle(&mut ctx, Direction::Next).unwrap();
+        let ids: Vec<u64> = ctx.state.windows.iter().map(|w| w.id).collect();
+        assert_eq!(ids, vec![2, 3, 1]);
+
+        // Reorder should have been called
+        assert!(!ctx.socket.sent_actions.is_empty());
+    }
+
+    #[test]
+    fn test_cycle_prev() {
+        let temp_dir = tempdir().unwrap();
+        let mut ctx = make_ctx(&temp_dir);
+
+        // [1, 2, 3] -> [3, 1, 2]
+        cycle(&mut ctx, Direction::Prev).unwrap();
+        let ids: Vec<u64> = ctx.state.windows.iter().map(|w| w.id).collect();
+        assert_eq!(ids, vec![3, 1, 2]);
+
+        assert!(!ctx.socket.sent_actions.is_empty());
+    }
+
+    #[test]
+    fn test_cycle_single_window_noop() {
+        let temp_dir = tempdir().unwrap();
+        let mut state = AppState::default();
+        state.windows.push(WindowState {
+            id: 1,
+            width: 300,
+            height: 200,
+            is_floating: true,
+            position: Some((1.0, 2.0)),
+        });
+
+        let mock = MockNiri::new(vec![mock_window(1, false, true, 1, Some((1.0, 2.0)))]);
+
+        let mut ctx = Ctx {
+            state,
+            config: mock_config(),
+            socket: mock,
+            cache_dir: temp_dir.path().to_path_buf(),
+        };
+
+        cycle(&mut ctx, Direction::Next).unwrap();
+        assert_eq!(ctx.state.windows.len(), 1);
+        assert_eq!(ctx.state.windows[0].id, 1);
+        assert!(ctx.socket.sent_actions.is_empty());
+    }
+}

--- a/src/commands/hide.rs
+++ b/src/commands/hide.rs
@@ -3,11 +3,18 @@ use crate::commands::reorder;
 use crate::niri::NiriClient;
 use crate::state::save_state;
 use anyhow::Result;
+use niri_ipc::Action;
 
 pub fn toggle_visibility<C: NiriClient>(ctx: &mut Ctx<C>) -> Result<()> {
-    ctx.state.is_hidden = !ctx.state.is_hidden;
+    let was_hidden = ctx.state.is_hidden;
+    ctx.state.is_hidden = !was_hidden;
     save_state(&ctx.state, &ctx.cache_dir)?;
     reorder(ctx)?;
+
+    if was_hidden && ctx.config.interaction.focus_on_unhide {
+        let _ = ctx.socket.send_action(Action::FocusFloating {});
+    }
+
     Ok(())
 }
 

--- a/src/commands/hide.rs
+++ b/src/commands/hide.rs
@@ -11,8 +11,12 @@ pub fn toggle_visibility<C: NiriClient>(ctx: &mut Ctx<C>) -> Result<()> {
     save_state(&ctx.state, &ctx.cache_dir)?;
     reorder(ctx)?;
 
-    if was_hidden && ctx.config.interaction.focus_on_unhide {
-        let _ = ctx.socket.send_action(Action::FocusFloating {});
+    if ctx.config.interaction.auto_focus_layer {
+        if was_hidden {
+            ctx.socket.send_action(Action::FocusFloating {})?;
+        } else {
+            ctx.socket.send_action(Action::FocusTiling {})?;
+        }
     }
 
     Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod close;
+mod cycle;
 mod flip;
 mod focus;
 mod hide;
@@ -8,6 +9,7 @@ mod reorder;
 mod togglewindow;
 
 pub use close::close;
+pub use cycle::cycle;
 pub use flip::toggle_flip;
 pub use focus::focus;
 pub use hide::toggle_visibility;

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,7 @@ pub struct Interaction {
     #[serde(default = "default_sticky")]
     pub sticky: bool,
     #[serde(default)]
-    pub focus_on_unhide: bool,
+    pub auto_focus_layer: bool,
 }
 
 impl Interaction {

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,8 @@ pub struct Interaction {
     pub position: SidebarPosition,
     #[serde(default = "default_sticky")]
     pub sticky: bool,
+    #[serde(default)]
+    pub focus_on_unhide: bool,
 }
 
 impl Interaction {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,11 @@ enum Commands {
     ToggleVisibility,
     /// Reverse the order of windows in the stack
     Flip,
+    /// Rotate the window order in the stack
+    Cycle {
+        #[arg(value_enum, default_value_t = Direction::Next)]
+        direction: Direction,
+    },
     /// Force re-stacking of windows
     Reorder,
     /// Close the focused window and reorder the sidebar
@@ -90,6 +95,7 @@ fn main() -> Result<()> {
         Commands::ToggleWindow => commands::toggle_window(&mut ctx)?,
         Commands::ToggleVisibility => commands::toggle_visibility(&mut ctx)?,
         Commands::Flip => commands::toggle_flip(&mut ctx)?,
+        Commands::Cycle { direction } => commands::cycle(&mut ctx, direction)?,
         Commands::Reorder => commands::reorder(&mut ctx)?,
         Commands::Close => commands::close(&mut ctx)?,
         Commands::Focus { direction } => commands::focus(&mut ctx, direction)?,


### PR DESCRIPTION
Adds a nix flake which exposes the package (or overlay) so NixOS users can easily integrate into their setup. Also adds a home-manager module which allows for easy installation / configuration and optionally enabling the listen daemon as a systemd service. 

Also added shell completion, which introduces clap_complete as a dependency. It is working fine for me on bash, but I have  not tested other shells.

Thanks for the cool project, happy to make any changes (including documenting in README).

Disclaimer: Claude helped with adding the shell completions.