### PR TITLE
chore: rename crate to niri-sidepanels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "niri-sidebar"
+name = "niri-sidepanels"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "niri-sidebar"
+name = "niri-sidepanels"
 version = "0.1.0"
 edition = "2024"
 

--- a/src/commands/listen.rs
+++ b/src/commands/listen.rs
@@ -14,7 +14,7 @@ use niri_ipc::{Event, Request, Window};
 pub fn listen(mut ctx: Ctx<Socket>) -> Result<()> {
     let _ = ctx.socket.send(Request::EventStream)?;
     let mut read_event = ctx.socket.read_events();
-    println!("niri-sidebar: Listening for window events...");
+    println!("niri-sidepanels: Listening for window events...");
 
     while let Ok(event) = read_event() {
         match event {

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,7 +93,7 @@ impl Default for Config {
 
 pub fn get_config_dir() -> Result<PathBuf> {
     let mut path = dirs::config_dir().context("Could not find config directory")?;
-    path.push("niri-sidebar");
+    path.push("niri-sidepanels");
     Ok(path)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use fslock::LockFile;
-use niri_sidebar::config::load_config;
-use niri_sidebar::state::{get_default_cache_dir, load_state};
-use niri_sidebar::{AppState, Ctx, config, niri::connect};
-use niri_sidebar::{Direction, commands};
+use niri_sidepanels::config::load_config;
+use niri_sidepanels::state::{get_default_cache_dir, load_state};
+use niri_sidepanels::{AppState, Ctx, config, niri::connect};
+use niri_sidepanels::{Direction, commands};
 
 #[derive(Parser)]
-#[command(name = "niri-sidebar")]
+#[command(name = "niri-sidepanels")]
 #[command(about = "A floating sidebar manager for Niri")]
 struct Cli {
     #[command(subcommand)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -25,7 +25,7 @@ pub struct WindowState {
 
 pub fn get_default_cache_dir() -> Result<PathBuf> {
     let mut path = dirs::cache_dir().context("Could not find cache directory")?;
-    path.push("niri-sidebar");
+    path.push("niri-sidepanels");
     if !path.exists() {
         fs::create_dir_all(&path)?;
     }


### PR DESCRIPTION
## Summary
First PR in the fork: rename the crate and all its identifiers from \`niri-sidebar\` to \`niri-sidepanels\`. No behavior changes — only string substitutions.

- \`Cargo.toml\` package name
- Library import path (\`niri_sidebar::\` → \`niri_sidepanels::\`)
- CLI binary name (clap \`#[command(name = ...)]\`)
- Config dir: \`~/.config/niri-sidebar/\` → \`~/.config/niri-sidepanels/\`
- Cache/state dir: same substitution
- Log prefix in the listen daemon

## Test plan
- [x] \`cargo check\` passes on rustc 1.95.
- [ ] Subsequent PRs will split config into \`[left]\` / \`[right]\` sections, thread a \`Side\` enum through state/commands, add the \`send {left|right|center}\` command, and replace fixed-height stacking with equal-division + configurable gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)