### PR TITLE
Added nix flake support for declarative installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+result

--- a/README.md
+++ b/README.md
@@ -71,6 +71,79 @@ sudo xbps-install --repository=hostdir/binpkgs niri-sidebar
 ```
 > **Note:** This package is community-maintained in the Void Linux community repository and is not officially maintained by the niri-sidebar project. Please review the template before installing.
 
+### Option 5: Nix / Home Manager
+
+A [Nix flake](https://nixos.wiki/wiki/Flakes) is provided with a Home Manager module for declarative configuration.
+
+#### Flake usage
+
+Add `niri-sidebar` to your flake inputs:
+
+```nix
+{
+  inputs = {
+    niri-sidebar.url = "github:Vigintillionn/niri-sidebar";
+  };
+
+  outputs =
+    { self, nixpkgs, niri-sidebar, ... }:
+    {
+      homeConfigurations."user" = nixpkgs.lib.nixosSystem {
+        modules = [
+          niri-sidebar.homeModules.default
+          {
+            programs.niri-sidebar = {
+              enable = true;
+              settings = {
+                geometry = {
+                  width = 400;
+                  height = 335;
+                  gap = 10;
+                };
+                margins = {
+                  top = 50;
+                  right = 10;
+                  left = 10;
+                  bottom = 10;
+                };
+                interaction = {
+                  position = "right";
+                  peek = 10;
+                  focus_peek = 50;
+                  sticky = false;
+                };
+              };
+            };
+          }
+        ];
+      };
+    };
+}
+```
+
+#### Legacy `default.nix` usage
+
+```nix
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  niri-sidebar = import (builtins.fetchTarball {
+    url = "https://github.com/Vigintillionn/niri-sidebar/archive/main.tar.gz";
+  }) { inherit pkgs; };
+in
+{
+  homeModule = niri-sidebar.homeModule;
+  package = niri-sidebar.package;
+}
+```
+
+#### Binary cache / ad-hoc
+
+```bash
+nix run github:Vigintillionn/niri-sidebar -- toggle-window
+nix build github:Vigintillionn/niri-sidebar
+```
+
 ## Niri configuration
 
 Add the following bindings to your niri `config.kdl` file.

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,26 @@
+let
+  inherit (builtins) fromJSON readFile;
+
+  lock = fromJSON (readFile ./flake.lock);
+  namedNode = lock.nodes.${lock.nodes.root.inputs.nixpkgs}.locked;
+  nixpkgs = fetchTarball {
+    inherit (namedNode) url;
+    sha256 = namedNode.narHash;
+  };
+in
+{
+  pkgs ? import nixpkgs { },
+}:
+let
+  inherit (pkgs.lib) mkDefault;
+
+  package = pkgs.callPackage ./nix/package.nix { };
+in
+{
+  homeModule = {
+    imports = [ ./nix/home-module.nix ];
+    programs.niri-sidebar.package = mkDefault package;
+  };
+
+  inherit package;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-rcUHdUtJEvMdNEl2Wq+YpHraHKfcer3KsBscpZEF2Yg=",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1017464.567a49d1913c/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "A lightweight, external sidebar manager for the Niri window manager";
+
+  inputs = {
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      inherit (nixpkgs.lib) genAttrs getExe;
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forEachSystem =
+        perSystem:
+        genAttrs systems (
+          system:
+          let
+            pkgs = nixpkgs.legacyPackages.${system};
+          in
+          perSystem { inherit pkgs system; }
+        );
+    in
+    {
+      overlays.default = final: prev: {
+        niri-sidebar = final.callPackage ./nix/package.nix { };
+      };
+
+      packages = forEachSystem (
+        { pkgs, ... }:
+        {
+          default = pkgs.callPackage ./nix/package.nix { };
+        }
+      );
+
+      devShells = forEachSystem (
+        { pkgs, system }:
+        {
+          default = pkgs.callPackage ./nix/devshell.nix {
+            niri-sidebar = self.packages.${system}.default;
+          };
+        }
+      );
+
+      apps = forEachSystem (
+        { system, ... }:
+        {
+          default = {
+            type = "app";
+            program = getExe self.packages.${system}.default;
+          };
+        }
+      );
+
+      homeModules.default =
+        { pkgs, lib, ... }:
+        {
+          imports = [ ./nix/home-module.nix ];
+          programs.niri-sidebar.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
+    };
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,90 @@
+
+## Publishing to Nix
+
+The project provides a Nix flake at the repository root. No separate publishing step is needed — users consume it directly from GitHub:
+
+```bash
+# Run directly
+nix run github:vigintillionn/niri-sidebar
+
+# Build locally
+nix build github:vigintillionn/niri-sidebar
+
+# Install via nix profile
+nix profile install github:vigintillionn/niri-sidebar
+```
+
+### Installing Nix on Any Linux Distro
+
+Nix is **not tied to NixOS** — it works as a package manager on any Linux distribution (Ubuntu, Arch, Fedora, etc.):
+
+1. Install Nix: `sh <(curl -L https://nixos.org/nix/install)`
+2. Enable flakes in `~/.config/nix/nix.conf`:
+   ```
+   experimental-features = nix-command flakes
+   ```
+3. Run the flake: `nix run github:vigintillionn/niri-sidebar`
+
+### Flake Input
+
+```nix
+inputs = {
+  dotstate.url = "github:vigintillionn/niri-sidebar";
+};
+```
+
+### Using the Overlay
+
+```nix
+nixpkgs.overlays = [ inputs.niri-sidebar.overlays.default ];
+environment.systemPackages = [ pkgs.niri-sidebar ];
+```
+
+### Using the Home Manager Module
+
+```nix
+imports = [ inputs.niri-sidebar.homeModules.default ];
+programs.niri-sidebar.enable = true;
+programs.niri-sidebar.settings = {
+    geometry = {
+        width = 400;
+        height = 335;
+        gap = 10;
+    };
+    margins = {
+        top = 50;
+        right = 10;
+        left = 10;
+        bottom = 10;
+    };
+    interaction = {
+        position = "bottom";
+        peek = 10;
+        focus_peek = 50;
+        sticky = true;
+    };
+};
+```
+
+### Non-Flake Usage
+
+```bash
+nix-build default.nix
+```
+
+### Updating Lockfiles (for maintainers)
+
+After source changes, run this from the repo root to regenerate `Cargo.lock` and `flake.lock`:
+
+```bash
+./nix/rebuild.sh
+```
+
+Then commit:
+
+```bash
+git add Cargo.lock flake.lock
+git commit -m "chore: update lockfiles"
+```
+
+> **Non-NixOS maintainers can still run this** — just install Nix on your distro first (see "Installing Nix on Any Linux Distro" above). The rebuild script only needs `cargo generate-lockfile`, `nix flake update`, and `nix build` — all available once Nix is installed.

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,19 @@
+{
+  pkgs,
+  niri-sidebar,
+}:
+pkgs.mkShell {
+  inputsFrom = [ niri-sidebar ];
+
+  nativeBuildInputs = with pkgs; [
+    cargo
+    clippy
+    rust-analyzer
+    rustc
+    rustfmt
+  ];
+
+  shellHook = ''
+    echo " niri-sidebar dev-shell | 'cargo build' to build | 'cargo test' to test"
+  '';
+}

--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.niri-sidebar;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.programs.niri-sidebar = {
+    enable = lib.mkEnableOption "Whether to enable niri-sidebar, a lightweight external sidebar manager for Niri.";
+
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = "The niri-sidebar package to use.";
+    };
+
+    settings = lib.mkOption {
+      type = with lib.types; nullOr (oneOf [ tomlFormat.type str path ]);
+      default = null;
+      description = ''
+        Configuration for niri-sidebar. Written to {file}`$XDG_CONFIG_HOME/niri-sidebar/config.toml`.
+        Can be a Nix attrset (converted to TOML), a raw TOML string, or a path to a `.toml` file.
+      '';
+      example = lib.literalExpression ''
+        {
+          geometry = {
+            width = 400;
+            height = 335;
+            gap = 10;
+          };
+          margins = {
+            top = 50;
+            right = 10;
+            left = 10;
+            bottom = 10;
+          };
+          interaction = {
+            position = "right";
+            peek = 10;
+            focus_peek = 50;
+            sticky = false;
+          };
+          window_rule = [
+            {
+              app_id = "firefox";
+              title = "^Picture-in-Picture$";
+              width = 700;
+              height = 400;
+              focus_peek = 710;
+              peek = 10;
+              auto_add = true;
+            }
+          ];
+        }
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.optional (cfg.package != null) cfg.package;
+
+    xdg.configFile = lib.mkIf (cfg.settings != null) {
+      "niri-sidebar/config.toml".source =
+        let
+          rawConfig =
+            if lib.isString cfg.settings then
+              pkgs.writeText "niri-sidebar-config.toml" cfg.settings
+            else if builtins.isPath cfg.settings || lib.isStorePath cfg.settings then
+              cfg.settings
+            else
+              tomlFormat.generate "niri-sidebar-config.toml" cfg.settings;
+        in
+        rawConfig;
+    };
+  };
+
+  _class = "homeManager";
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+}:
+let
+  inherit (builtins) readFile;
+  cargoToml = builtins.fromTOML (readFile ../Cargo.toml);
+  version = cargoToml.package.version;
+in
+rustPlatform.buildRustPackage {
+  pname = "niri-sidebar";
+  inherit version;
+
+  src = lib.cleanSource ../.;
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+  };
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "A lightweight, external sidebar manager for the Niri window manager";
+    homepage = "https://github.com/Vigintillionn/niri-sidebar";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.linux;
+    mainProgram = "niri-sidebar";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/nix/rebuild.sh
+++ b/nix/rebuild.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+echo " niri-sidebar v$version"
+
+echo "Updating Cargo.lock..."
+cargo generate-lockfile
+
+echo "Updating flake.lock..."
+nix flake update
+
+echo "Building..."
+nix build
+
+echo "Done - result at ./result ($(./result/bin/niri-sidebar --version))"

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/3xfvxhbjwk155yx6z08h7ciycq4l9p4r-niri-sidebar-0.1.0

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/3xfvxhbjwk155yx6z08h7ciycq4l9p4r-niri-sidebar-0.1.0


### PR DESCRIPTION
Installed on my nixos system ok, can be installed onto nixos or a other distros with the nix home manager toolset. I've added some basic info on installing to the main doc, also added a README.md to the nix folder detailing instructions on publishing any updates for the flake as well.